### PR TITLE
Convert pyproject_autoflake a module to directly execute it

### DIFF
--- a/pyproject_autoflake/__main__.py
+++ b/pyproject_autoflake/__main__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from pyproject_autoflake.pautoflake import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In order to avoid No module named `pyproject_autoflake.__main__`; 'pyproject_autoflake' is a package and cannot be directly executed.